### PR TITLE
Prevents trying to find an identity based on an empty regex

### DIFF
--- a/lib/easy_auth/password/models/account.rb
+++ b/lib/easy_auth/password/models/account.rb
@@ -60,7 +60,7 @@ module EasyAuth::Password::Models::Account
 
   def update_password_identities
     identity_uid_attributes.each do |attribute|
-      if send("#{attribute}_changed?")
+      if send("#{attribute}_changed?") && send("#{attribute}_was").try(:present?)
         identity = password_identities.find { |identity| identity.uid =~ match(send("#{attribute}_was")) }
       else
         identity = password_identities.find { |identity| identity.uid =~ match(send(attribute)) }


### PR DESCRIPTION
Ran into an issue in another application which caused extra identities
to be created, when the value went from nil to a value. Cannot recreate
in this test suite, but this solves the issue in the application
