### PR TITLE
Rails42 update

### DIFF
--- a/easy_auth-password.gemspec
+++ b/easy_auth-password.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl', '~> 2.6.0'
   s.add_development_dependency 'mocha', '~> 0.10.5'
   s.add_development_dependency 'launchy'
-  s.add_development_dependency 'rails', '< 4.2'
+  s.add_development_dependency 'rails', '~> 4.2'
   s.add_development_dependency 'test-unit'
 end

--- a/lib/easy_auth/controllers/password_reset.rb
+++ b/lib/easy_auth/controllers/password_reset.rb
@@ -12,7 +12,7 @@ module EasyAuth::Controllers::PasswordReset
   def create
     if @identity = EasyAuth.find_identity_model(params).where(:uid => params[:identities_password][:uid]).first
       unencrypted_reset_token = @identity.generate_reset_token!
-      PasswordResetMailer.reset(@identity.id, unencrypted_reset_token).deliver
+      PasswordResetMailer.reset(@identity.id, unencrypted_reset_token).deliver_now
       after_successful_attempted_password_reset
     else
       @identity = EasyAuth.find_identity_model(params).new(uid: params[:identities_password][:uid])

--- a/lib/easy_auth/password/models/identity.rb
+++ b/lib/easy_auth/password/models/identity.rb
@@ -10,7 +10,7 @@ module EasyAuth::Password::Models::Identity
   #
   # @param [Boolean] value
   def remember=(value)
-    @remember = ::ActiveRecord::ConnectionAdapters::Column.value_to_boolean(value)
+    @remember = ::ActiveRecord::Type::Boolean.new.type_cast_from_database(value)
   end
 
   # Generates a new remember token and updates it on the identity record

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -9,7 +9,7 @@ Dummy::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -8,7 +8,7 @@ Dummy::Application.configure do
   config.cache_classes = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching


### PR DESCRIPTION
Rails 4 deprecated  ::ActiveRecord::ConnectionAdapters::Column.value_to_boolean(value) and it was removed in 4.2.0

A pretty solid replacement implementation seems like ::ActiveRecord::Type::Boolean.new.type_cast_from_database(value), though it would probably work just to use !!value

I also updated the dummy file to remove deprecation warnings and added the gems I needed to get the specs running to the gemspec.
