### PR TITLE
Update password.rb

### DIFF
--- a/lib/easy_auth/models/identities/password.rb
+++ b/lib/easy_auth/models/identities/password.rb
@@ -51,7 +51,9 @@ module EasyAuth::Models::Identities::Password
   end
 
   def authenticate(unencrypted_token, token_name = :password)
-    SCrypt::Password.new(send("#{token_name}_digest")) == unencrypted_token && self
+    token_value = send("#{token_name}_digest")
+    return false unless token_value
+    SCrypt::Password.new(token_value) == unencrypted_token && self
   end
 
   def password=(unencrypted_password)

--- a/spec/models/identities/password_spec.rb
+++ b/spec/models/identities/password_spec.rb
@@ -53,13 +53,22 @@ describe Identities::Password do
   end
 
   describe '#password_reset' do
-    it 'sets a unique reset token' do
-      identity = create(:password_identity, :account => build(:user))
-      identity.reset_token_digest.should be_nil
-      unencrypted_token = identity.generate_reset_token!
-      identity = Identities::Password.last
-      identity.reset_token_digest.should_not be_nil
-      SCrypt::Password.new(identity.reset_token_digest).should eq unencrypted_token
+    context 'normal process flow' do
+      it 'sets a unique reset token' do
+        identity = create(:password_identity, :account => build(:user))
+        identity.reset_token_digest.should be_nil
+        unencrypted_token = identity.generate_reset_token!
+        identity = Identities::Password.last
+        identity.reset_token_digest.should_not be_nil
+        SCrypt::Password.new(identity.reset_token_digest).should eq unencrypted_token
+      end
+    end
+    context 'attempt without a reset token' do
+      it 'returns false' do
+        identity = create(:password_identity, :account => build(:user))
+        identity.reset_token_digest.should be_nil
+        identity.authenticate('bad_unencrypted_token', :reset_token_digest).should be_false
+      end
     end
   end
 end

--- a/spec/models/identities/password_spec.rb
+++ b/spec/models/identities/password_spec.rb
@@ -67,7 +67,7 @@ describe Identities::Password do
       it 'returns false' do
         identity = create(:password_identity, :account => build(:user))
         identity.reset_token_digest.should be_nil
-        identity.authenticate('bad_unencrypted_token', :reset_token_digest).should be_false
+        identity.authenticate('bad_unencrypted_token', :reset_token).should be_false
       end
     end
   end


### PR DESCRIPTION
We are getting bots/spiders attempting to visit bogus password reset URLs for users that do not have a reset_token_digest created on their Identity record.  This will result in SCrypt throwing an exception because the authenticate method will attempt to pass it a nil token.  Prevent this by checking the value before sending it to SCrypt.